### PR TITLE
Catch all subdirectories from .app/usr/lib

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -61,20 +61,22 @@ for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
 done
 
 topic "Writing profile script"
+lib_paths=`cd $BUILD_DIR; find .apt/usr/lib -depth -type d | sed 's/^/\$HOME\//' | tr "\\n" :`
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_apt.sh
 export PATH="\$HOME/.apt/usr/bin:\$PATH"
-export LD_LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LD_LIBRARY_PATH"
-export LIBRARY_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/lib/i386-linux-gnu:\$HOME/.apt/usr/lib:\$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$lib_paths\$LD_LIBRARY_PATH"
+export LIBRARY_PATH="$lib_paths\$LIBRARY_PATH"
 export INCLUDE_PATH="\$HOME/.apt/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
 EOF
 
+lib_paths=`find $BUILD_DIR/.apt/usr/lib -depth -type d | tr "\\n" :`
 export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
-export LD_LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LD_LIBRARY_PATH"
-export LIBRARY_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu:$BUILD_DIR/.apt/usr/lib:$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$lib_paths$LD_LIBRARY_PATH"
+export LIBRARY_PATH="$lib_paths$LIBRARY_PATH"
 export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$INCLUDE_PATH"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"


### PR DESCRIPTION
Include .app/usr/lib and its sub directories for `LD_LIBRARY_PATH` and `LIBRARY_PATH`

Some apt packages leave their libraries under sub-directories of `/usr/lib` and let Debian alternatives system create symbolic links back to `/usr/lib`. Because builpack-apt can not run alternatives, those libraries can not be found by binaries installed by buildpack-apt unless their paths are included in `LD_LIBRARY_PATH` and `LIBRARY_PATH`. For example, `ogr2ogr` command from gdal-bin package requires `libblas.so.3` installed in `/usr/lib/libblas/`.

This pull request is to let the build process find sub-directories of `/usr/lib` so that those libraries will be found by linker when a binary is executed.

