### PR TITLE
Rewrite package-config files.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -85,7 +85,7 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APP_DIR"'/.apt\1!g'
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix=$BUILD_DIR/.apt\1!g'
 ## DEBUG
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat

--- a/bin/compile
+++ b/bin/compile
@@ -85,9 +85,3 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
-## DEBUG
-echo "echo ***** HELLO WORLD" >> "$LP_DIR/export"
-cat $LP_DIR/export
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
-## END DEBUG

--- a/bin/compile
+++ b/bin/compile
@@ -85,3 +85,7 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+## DEBUG
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
+## END DEBUG

--- a/bin/compile
+++ b/bin/compile
@@ -84,8 +84,9 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$LP_DIR"'/.apt\1!g'
 ## DEBUG
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
+ehco $LP_DIR
+find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
+find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
 ## END DEBUG

--- a/bin/compile
+++ b/bin/compile
@@ -82,3 +82,6 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 
 #give environment to later buildpacks
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
+
+topic "Rewrite package-config files"
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'

--- a/bin/compile
+++ b/bin/compile
@@ -84,4 +84,4 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,6 @@ set -e
 BUILD_DIR=$1
 CACHE_DIR=$2
 LP_DIR=`cd $(dirname $0); cd ..; pwd`
-APP_DIR=/app
 
 function error() {
   echo " !     $*" >&2
@@ -85,8 +84,10 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
-find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix=$BUILD_DIR/.apt\1!g'
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
 ## DEBUG
+echo "echo ***** HELLO WORLD" >> "$LP_DIR/export"
+cat $LP_DIR/export
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
 ## END DEBUG

--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,7 @@ set -e
 BUILD_DIR=$1
 CACHE_DIR=$2
 LP_DIR=`cd $(dirname $0); cd ..; pwd`
+APP_DIR=/app
 
 function error() {
   echo " !     $*" >&2
@@ -84,9 +85,8 @@ export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUIL
 export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
-find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$LP_DIR"'/.apt\1!g'
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APP_DIR"'/.apt\1!g'
 ## DEBUG
-ehco $LP_DIR
-find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
-find $LP_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs echo
+find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs -n 1 cat
 ## END DEBUG


### PR DESCRIPTION
I encountered some issues with some APT packages (libxmlsec, for example) that depend on *.pc files for other packages to locate their libraries, etc. Because the APT packages are extracted to non-standard locations the *.pc files do not contain the correct prefixes. I've modified the buildpack to replace the prefix values.