### PR TITLE
Update README for new multiple buildpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ Add support for apt-based dependencies during both compile and runtime.
 
 ## Usage
 
-This buildpack works best with [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi) so that it can be used with your app's existing buildpacks.
+This buildpack is not meant to be used on its own, and instead should be in used in combination with Heroku's [multiple buildpack support](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
 Include a list of apt package names to be installed in a file named `Aptfile`
 
 ## Example
 
-#### .buildpacks
+#### Command-line
 
-    https://github.com/ddollar/heroku-buildpack-apt
-    https://github.com/heroku/heroku-buildpack-ruby
+```
+heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
+```
 
 #### Aptfile
 
@@ -24,38 +25,7 @@ Include a list of apt package names to be installed in a file named `Aptfile`
 
     source "https://rubygems.org"
     gem "pg"
-    
-### Compile with [Anvil](https://github.com/ddollar/anvil-cli)
 
-    $ heroku plugins:install https://github.com/ddollar/heroku-build
-    
-    $ heroku create apt-pg-test
-    
-    $ heroku build . -b ddollar/multi -r 
-	Checking for app files to sync... done, 2 files needed
-	Uploading: 100.0%
-	Launching build process... done
-	Preparing app for compilation... done
-	Fetching buildpack... done
-	Detecting buildpack... done, Multipack
-	Fetching cache... done
-	Compiling app...
-	=====> Downloading Buildpack: https://github.com/ddollar/heroku-buildpack-apt
-	=====> Detected Framework: Apt
-	  Updating apt caches
-	  ...
-	  Installing libpq-dev_8.4.17-0ubuntu10.04_amd64.deb
-	  Installing libpq5_8.4.17-0ubuntu10.04_amd64.deb
-	  Writing profile script
-	=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-ruby
-	=====> Detected Framework: Ruby
-	  Installing dependencies using Bundler version 1.3.2
-	  ...
-	Putting cache... done
-	Creating slug... done
-	Uploading slug... done
-	Success, slug is https://api.anvilworks.org/slugs/00000000-0000-0000-0000-0000000000.tgz
-	
 ### Check out the PG library version
 
     $ heroku run bash -a apt-pg-test


### PR DESCRIPTION
This updates the README of this project to reference Heroku's new multiple buildpack support, instead of the [deprecated](https://github.com/ddollar/heroku-buildpack-multi/blob/master/bin/compile#L8-L13) heroku-buildpack-multi.

I also went ahead and removed documentation referencing Anvil, which appears to have been a personal project of this buildpack's creator that is no longer maintained.