### PR TITLE
Added support for package sources in Aptfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Add support for apt-based dependencies during both compile and runtime.
 
+Added ability to also specify custom repositories through **:repo:** in `Aptfile` (see example below).
+
 ## Usage
 
 This buildpack is not meant to be used on its own, and instead should be in used in combination with Heroku's [multiple buildpack support](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
@@ -20,6 +22,7 @@ heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
 
     libpq-dev
     http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-precise-amd64.deb
+    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
 
 #### Gemfile
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,16 +31,35 @@ function indent() {
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
+APT_SOURCELIST_DIR="$CACHE_DIR/apt/sources"   # place custom sources.list here
 
-mkdir -p "$APT_CACHE_DIR/archives/partial"
-mkdir -p "$APT_STATE_DIR/lists/partial"
+APT_SOURCES="$APT_SOURCELIST_DIR/sources.list"
+
+if [ -f $APT_CACHE_DIR/Aptfile ] && cmp -s $BUILD_DIR/Aptfile $APT_CACHE_DIR/Aptfile ; then
+  # Old Aptfile is the same as new
+  topic "Reusing cache"
+else
+  # Aptfile changed or does not exist
+  topic "Detected Aptfile changes, flushing cache"
+  rm -rf $APT_CACHE_DIR
+  mkdir -p "$APT_CACHE_DIR/archives/partial"
+  mkdir -p "$APT_STATE_DIR/lists/partial"
+  mkdir -p "$APT_SOURCELIST_DIR"   # make dir for sources
+  cp -f "$BUILD_DIR/Aptfile" "$APT_CACHE_DIR/Aptfile"
+  cat "/etc/apt/sources.list" > "$APT_SOURCES"    # no cp here
+  # add custom repositories from Aptfile to sources.list
+  # like>>    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
+  topic "Adding custom repositories"
+  cat $BUILD_DIR/Aptfile | grep -s -e "^:repo:" | sed 's/^:repo:\(.*\)\s*$/\1/g' >> $APT_SOURCES
+fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
+APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
-for PACKAGE in $(cat $BUILD_DIR/Aptfile); do
+for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:"); do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb


### PR DESCRIPTION
See modified [README.MD](https://github.com/thodnev/heroku-buildpack-apt/blob/291790493666b97b2403b049662d4ea3b16a0874/README.md) for use case.
Basically it's a needed feature, because now user could simply mention the needed repository in Aptfile and don't need to resolve dependencies by hand and put numerous `.deb` files in Aptfile