### PR TITLE
Remove deprecated option and use noninteractive instead

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:"); do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    DEBIAN_FRONTEND=noninteractive apt-get $APT_OPTIONS -y -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
`--force-yes` causes this warning when building:
```
W: --force-yes is deprecated, use one of the options starting with --allow instead.
```

Plus is [strongly discouraged on apt-get's manpage](http://manpages.ubuntu.com/manpages/xenial/en/man8/apt-get.8.html):
> Force yes; this is a dangerous option that will cause apt to continue without prompting if it is doing something potentially harmful. It should not be used except in very special situations. Using force-yes can potentially destroy your system!...