### PR TITLE
Add support for specifying a custom key to be added to the trusted keys

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,7 @@ function indent() {
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
 APT_SOURCELIST_DIR="$CACHE_DIR/apt/sources"   # place custom sources.list here
+APT_TRUSTED_DIR="$CACHE_DIR/apt/trusted.gpg.d"
 
 APT_SOURCES="$APT_SOURCELIST_DIR/sources.list"
 
@@ -42,24 +43,39 @@ else
   # Aptfile changed or does not exist
   topic "Detected Aptfile changes, flushing cache"
   rm -rf $APT_CACHE_DIR
+  rm -rf "$APT_TRUSTED_DIR"
   mkdir -p "$APT_CACHE_DIR/archives/partial"
   mkdir -p "$APT_STATE_DIR/lists/partial"
   mkdir -p "$APT_SOURCELIST_DIR"   # make dir for sources
+  mkdir -p "$APT_TRUSTED_DIR"   # make dir for trusted keys
   cp -f "$BUILD_DIR/Aptfile" "$APT_CACHE_DIR/Aptfile"
+  cp -f /etc/apt/trusted.gpg.d/* "$APT_TRUSTED_DIR" # copy existing keys to new trusted keys dir
   cat "/etc/apt/sources.list" > "$APT_SOURCES"    # no cp here
+
   # add custom repositories from Aptfile to sources.list
   # like>>    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
   topic "Adding custom repositories"
   cat $BUILD_DIR/Aptfile | grep -s -e "^:repo:" | sed 's/^:repo:\(.*\)\s*$/\1/g' >> $APT_SOURCES
+
+  # add custom keys from Aptfile to to the trusted keys directory
+  # like>>    :key:name:https://nginx.org/keys/nginx_signing.key
+  for key in $(cat $BUILD_DIR/Aptfile |grep -s -e '^:key:'| sed 's/^:key:\(.*\)\s*$/\1/g'); do
+    name=$(echo "$key"|sed 's/^\([^:]*\):.*$/\1/')
+    url=$(echo "$key"|sed 's/^[^:]*://')
+
+    topic "adding key for $name"
+    curl -sS "$url" | gpg --dearmor > "$APT_TRUSTED_DIR/$name.gpg"
+  done
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
+APT_OPTIONS="$APT_OPTIONS -o dir::etc::trustedparts=$APT_TRUSTED_DIR"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
-for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:"); do
+for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:" | grep -v -s -e "^:key:"); do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb


### PR DESCRIPTION
This should resolve #33

Add a key with the following format:

    :key:name:url

For example:

    :key:nginx:https://nginx.org/keys/nginx_signing.key
    :key:confluent:http://packages.confluent.io/deb/4.1/archive.key


I tested this with the following `Aptfile` (this is @catkhuu's example and the package I got stuck on without having a key):

```Aptfile
:key:nginx:https://nginx.org/keys/nginx_signing.key
:repo:deb http://nginx.org/packages/ubuntu/ xenial nginx
nginx-nr-agent
:key:confluent:http://packages.confluent.io/deb/4.1/archive.key
:repo:deb [arch=amd64] http://packages.confluent.io/deb/4.0 stable main
confluent-kafka-2.11
confluent-schema-registry
```