### PR TITLE
Add support for GObject Introspection

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,7 @@ export INCLUDE_PATH="\$HOME/.apt/usr/include:\$HOME/.apt/usr/include/x86_64-linu
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/i386-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
+export GI_TYPELIB_PATH="\$HOME/.apt/usr/lib/x86_64-linux-gnu/girepository-1.0:\$HOME/.apt/usr/lib/i386-linux-gnu/girepository-1.0:\$GI_TYPELIB_PATH"
 EOF
 
 export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"
@@ -98,9 +99,10 @@ export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$BUILD_DIR/.apt/usr/include/x86
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
+export GI_TYPELIB_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/girepository-1.0:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/girepository-1.0:$GI_TYPELIB_PATH"
 
 #give environment to later buildpacks
-export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
+export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH|GI_TYPELIB_PATH)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'


### PR DESCRIPTION
Add `GI_TYPELIB_PATH` to search `.typelib` files.

Context:
https://github.com/ruby-gnome2/ruby-gnome2/issues/1257#issuecomment-451049702