### PR TITLE
Prevent APT using source lists from /etc/apt/sources.list.d/

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,8 @@ else
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
+# Override the use of /etc/apt/sources.list (sourcelist) and /etc/apt/sources.list.d/* (sourceparts).
+APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=-"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent

--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,7 @@ fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 # Override the use of /etc/apt/sources.list (sourcelist) and /etc/apt/sources.list.d/* (sourceparts).
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=-"
+APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sourceparts=/dev/null"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent


### PR DESCRIPTION
Previously the buildpack only passed `-o dir::etc::sourcelist` to APT, which meant that APT still used the default `sourceparts` location of `/etc/apt/sources.list.d/`.

This meant on cedar-14 this buildpack would use esm.ubuntu.com as an APT source (as of heroku/stack-images/pull/140), which results in errors if the requested packages happened to have ESM-only updates available (since the ESM repository requires credentials since it's a paid Ubuntu offering).

Fixes #45 / [W-6224944](https://gus.my.salesforce.com/a07B0000006vf15IAA).