### PR TITLE
Fix up xmlsec1-config file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,3 +105,4 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+find $BUILD_DIR/.apt -type f -name 'xmlsec1-config' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix="\(.*\)"$!prefix="'"$BUILD_DIR"'/.apt\1"!g' -e 's!^libdir="\(.*\)"$!libdir="'"$BUILD_DIR"'/.apt\1"!g'


### PR DESCRIPTION
It's effectively a pkg-config file, but not exactly. This is required to install dm.xmlsec.binding 1.3.7 without additional changes.

The source file normally contains, e.g.,
```
prefix="/usr"
package="xmlsec1"
exec_prefix="${prefix}"
exec_prefix_set=no
libdir="/usr/lib64"
```

And this command fixes up the prefix and libdir. Tested to successfully install the python-saml package (which depends on dm.xmlsec.binding) with this change. Previously there was an error finding xmlsec/crypto.h due to incorrect include path.

I am loathe to add 1000 fixups like this, but I also don't see a substantially better way. Hopefully the number of such non-standard config files globally will be limited given pkg-config's popularity.