### PR TITLE
Cache stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,13 @@ function indent() {
   esac
 }
 
+# Store which STACK we are running on in the cache to bust the cache if it changes
+if [ -f $CACHE_DIR/.apt/STACK ]; then
+  CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")
+else
+  CACHED_STACK=$STACK
+fi
+
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
 APT_SOURCELIST_DIR="$CACHE_DIR/apt/sources"   # place custom sources.list here
@@ -42,7 +49,7 @@ case "$APT_VERSION" in
   *)         APT_FORCE_YES="--allow-downgrades --allow-remove-essential --allow-change-held-packages";;
 esac
 
-if [ -f $APT_CACHE_DIR/Aptfile ] && cmp -s $BUILD_DIR/Aptfile $APT_CACHE_DIR/Aptfile ; then
+if [ -f $APT_CACHE_DIR/Aptfile ] && cmp -s $BUILD_DIR/Aptfile $APT_CACHE_DIR/Aptfile && [[ $CACHED_STACK == $STACK ]] ; then
   # Old Aptfile is the same as new
   topic "Reusing cache"
 else
@@ -112,3 +119,6 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
+
+# Store which STACK we are running on in the cache to bust the cache if it changes
+echo "$STACK" > "$CACHE_DIR/.apt/STACK"

--- a/bin/compile
+++ b/bin/compile
@@ -34,6 +34,9 @@ if [ -f $CACHE_DIR/.apt/STACK ]; then
   CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")
 else
   CACHED_STACK=$STACK
+  # Store the STACK in the cache for next time.
+  mkdir -p "$CACHE_DIR/.apt"
+  echo "$STACK" > "$CACHE_DIR/.apt/STACK"
 fi
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
@@ -119,6 +122,3 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
-
-# Store which STACK we are running on in the cache to bust the cache if it changes
-echo "$STACK" > "$CACHE_DIR/.apt/STACK"

--- a/bin/compile
+++ b/bin/compile
@@ -53,11 +53,11 @@ case "$APT_VERSION" in
 esac
 
 if [ -f $APT_CACHE_DIR/Aptfile ] && cmp -s $BUILD_DIR/Aptfile $APT_CACHE_DIR/Aptfile && [[ $CACHED_STACK == $STACK ]] ; then
-  # Old Aptfile is the same as new
+  # Old Aptfile is the same as new and STACK has not changed
   topic "Reusing cache"
 else
-  # Aptfile changed or does not exist
-  topic "Detected Aptfile changes, flushing cache"
+  # Aptfile changed or does not exist or STACK changed
+  topic "Detected Aptfile or Stack changes, flushing cache"
   rm -rf $APT_CACHE_DIR
   mkdir -p "$APT_CACHE_DIR/archives/partial"
   mkdir -p "$APT_STATE_DIR/lists/partial"

--- a/bin/compile
+++ b/bin/compile
@@ -34,10 +34,11 @@ if [ -f $CACHE_DIR/.apt/STACK ]; then
   CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")
 else
   CACHED_STACK=$STACK
-  # Store the STACK in the cache for next time.
-  mkdir -p "$CACHE_DIR/.apt"
-  echo "$STACK" > "$CACHE_DIR/.apt/STACK"
 fi
+
+# Ensure we store the STACK in the cache for next time.
+mkdir -p "$CACHE_DIR/.apt"
+echo "$STACK" > "$CACHE_DIR/.apt/STACK"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -3,11 +3,7 @@
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 
 testCompile() {
-  cat > ${BUILD_DIR}/Aptfile <<EOF
-# Test comment
-s3cmd
-wget
-EOF
+  loadFixture "Aptfile"
 
   compile
 
@@ -17,4 +13,8 @@ EOF
   assertCaptured "Installing s3cmd_"
   assertCaptured "Fetching .debs for wget"
   assertCaptured "Installing wget_"
+}
+
+loadFixture() {
+  cp -a $BUILDPACK_HOME/test/fixtures/$1/. ${BUILD_DIR}
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -46,14 +46,12 @@ testStackNoChange() {
 }
 
 testStackCached() {
-  # Test that we are correctly storing the value of STACK in the cache
   loadFixture "Aptfile"
 
   compile
   assertCapturedSuccess
 
-  CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")
-  assertTrue 'STACK not cached' "[[ $CACHED_STACK == $STACK ]]"
+  assertTrue 'STACK not cached' "[ -e $CACHE_DIR/.apt/STACK ]"
 }
 
 loadFixture() {

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -15,6 +15,36 @@ testCompile() {
   assertCaptured "Installing wget_"
 }
 
+testStackChange() {
+  loadFixture "Aptfile"
+
+  #Set the cached STACK value to a non-existent stack, so it is guaranteed to change.
+  mkdir -p "$CACHE_DIR/.apt/"
+  echo "cedar-10" > "$CACHE_DIR/.apt/STACK"
+  
+  #Load the Aptfile into the cache, to exclusively test the stack changes
+  mkdir -p "$CACHE_DIR/apt/cache"
+  cp $BUILD_DIR/Aptfile "$CACHE_DIR/apt/cache"
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Detected Aptfile or Stack changes, flushing cache"
+}
+
+testStackNoChange() {
+  loadFixture "Aptfile"
+
+  #Load the Aptfile into the cache, to exclusively test the stack changes
+  mkdir -p "$CACHE_DIR/apt/cache"
+  cp $BUILD_DIR/Aptfile "$CACHE_DIR/apt/cache"
+
+  compile
+
+  assertCaptured "Reusing cache"
+}
+
 loadFixture() {
   cp -a $BUILDPACK_HOME/test/fixtures/$1/. ${BUILD_DIR}
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -45,6 +45,17 @@ testStackNoChange() {
   assertCaptured "Reusing cache"
 }
 
+testStackCached() {
+  # Test that we are correctly storing the value of STACK in the cache
+  loadFixture "Aptfile"
+
+  compile
+  assertCapturedSuccess
+
+  CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")
+  assertTrue 'STACK not cached' "[[ $CACHED_STACK == $STACK ]]"
+}
+
 loadFixture() {
   cp -a $BUILDPACK_HOME/test/fixtures/$1/. ${BUILD_DIR}
 }

--- a/test/fixtures/Aptfile/Aptfile
+++ b/test/fixtures/Aptfile/Aptfile
@@ -1,0 +1,3 @@
+# Test comment
+s3cmd
+wget


### PR DESCRIPTION
This PR fixes #48 - it adds the current stack to the cache and the bust's the cache if the stack has changed.

I also took the opportunity to refactor the tests and add two new ones for this change. The addition of fixtures should make it easier to add new tests based on different Aptfile configurations in the future.