### PR TITLE
Reduce log noise with apt-get -qq

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ else
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
+APT_OPTIONS="-qq $APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent

--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e "^:repo:"); do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    DEBIAN_FRONTEND=noninteractive apt-get $APT_OPTIONS -y -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
For some reason heroku build logs are truncated and don't show the actual error, so going to try to reduce the size by passing `-qq` into `apt-get`, which should only show errors instead of a bunch of informational logs