### PR TITLE
Fail the build if apt-get or curl errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # APT Buildpack Changelog
 
-## Unreleased
+## 2021-01-15
 
+- Fail the build if `apt-get` or `curl` errors ([#79](https://github.com/heroku/heroku-buildpack-apt/pull/79)).
+- Only try to add custom repositories when some are defined in `Aptfile` ([#79](https://github.com/heroku/heroku-buildpack-apt/pull/79)).
 
 ## 2019-10-17
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,7 @@
 # bin/compile <build-dir> <cache-dir>
 
 # fail fast
-set -e
+set -eo pipefail
 
 # debug
 # set -x
@@ -67,8 +67,10 @@ else
   cat "/etc/apt/sources.list" > "$APT_SOURCES"    # no cp here
   # add custom repositories from Aptfile to sources.list
   # like>>    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
-  topic "Adding custom repositories"
-  cat $BUILD_DIR/Aptfile | grep -s -e "^:repo:" | sed 's/^:repo:\(.*\)\s*$/\1/g' >> $APT_SOURCES
+  if grep -q -e "^:repo:" $BUILD_DIR/Aptfile; then
+    topic "Adding custom repositories"
+    cat $BUILD_DIR/Aptfile | grep -s -e "^:repo:" | sed 's/^:repo:\(.*\)\s*$/\1/g' >> $APT_SOURCES
+  fi
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
@@ -84,7 +86,7 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e '^#' | grep -v -s -e "^:
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb
 
     topic "Fetching $PACKAGE"
-    curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
+    curl --silent --show-error --fail -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
     apt-get $APT_OPTIONS -y $APT_FORCE_YES -d install --reinstall $PACKAGE | indent


### PR DESCRIPTION
Enables the bash `pipefail` mode, which ensures that a failure in a command prior to a pipe correctly causes the script to exit 1.

Without this, failures during the `apt-get` and `curl` invocations were ignored and the compile marked as a success. At best this leads to confusing errors in later buildpacks (if build time dependencies are missing), and at worst this could cause runtime failures for packages not used during the build, but required by the app at runtime.

Enabling `pipefail` mode required a change to the custom repositories feature, to prevent the build exiting 1 when `grep -s -e "^:repo:"` found no matches (ie when no custom repositories are specified).

In addition, the `--show-error` and `--fail` flags have been added to the `curl` call, otherwise non-HTTP 200 exit codes are ignored and the compile similarly marked as successful when it should not have been.

Fixes #47.
Fixes [W-8722791](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008mZ2UIAU/view).