### PR TITLE
Docs: Make the example more obviously an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Added ability to also specify custom repositories through **:repo:** in `Aptfile
 
 This buildpack is not meant to be used on its own, and instead should be in used in combination with Heroku's [multiple buildpack support](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
-Include a list of apt package names to be installed in a file named `Aptfile`
+Include a list of apt package names to be installed in a file named `Aptfile`.
+
+To find out what packages are available, see:
+<https://packages.ubuntu.com>
+
+See the [Heroku Stacks](https://devcenter.heroku.com/articles/stack) documention for which
+Ubuntu LTS version is used by each Heroku stack.
 
 ## Example
 
@@ -29,25 +35,13 @@ heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
 #### Aptfile
 
     # you can list packages
-    libpq-dev
+    libexample-dev
+    
     # or include links to specific .deb files
-    http://downloads.sourceforge.net/project/wkhtmltopdf/0.12.1/wkhtmltox-0.12.1_linux-precise-amd64.deb
-    # or add custom apt repos
-    :repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
-
-#### Gemfile
-
-    source "https://rubygems.org"
-    gem "pg"
-
-### Check out the PG library version
-
-    $ heroku run bash -a apt-pg-test
-    ~ $ irb
-	irb(main):001:0> require "pg"
-	=> true
-	irb(main):002:0> PG::version_string
-	=> "PG 0.15.1"
+    https://downloads.example.com/example.deb
+    
+    # or add custom apt repos (only required if using packages outside of the standard Ubuntu APT repositories)
+    :repo:deb https://apt.example.com/ example-distro main
 
 ## License
 


### PR DESCRIPTION
In a recent [support ticket](https://heroku.support/953899), a user had copied the example `:repo:` line into their `Aptfile`, which previously referred to the now obsolete "artful" Ubuntu LTS release.

This caused the build to fail after #79, when previously the error was ignored.

This PR makes the example more clearly just an example, and emphasises that using a custom repository is only necessary if using packages from outside the standard Ubuntu repository.

In addition, the bogus `pg` Gem example was removed, since `libpq-dev` is part of the stack image, so we should not be encouraging people to install it unnecessarily.

[skip changelog]