### PR TITLE
Output a helpful error message when no Aptfile is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # APT Buildpack Changelog
 
+## Unreleased
+
+- Output a helpful error message when no `Aptfile` is found ([#87](https://github.com/heroku/heroku-buildpack-apt/pull/87)).
+
 ## 2021-01-15
 
 - Fail the build if `apt-get` or `curl` errors ([#79](https://github.com/heroku/heroku-buildpack-apt/pull/79)).

--- a/bin/detect
+++ b/bin/detect
@@ -2,7 +2,9 @@
 # bin/detect <build-dir>
 
 if [ -f $1/Aptfile ]; then
-  echo "Apt" && exit 0
+  echo "Apt"
+  exit 0
 else
-  echo "no" && exit 1
+  echo "Could not find an 'Aptfile'! Please ensure it exists and is checked into Git." >&2
+  exit 1
 fi


### PR DESCRIPTION
The error message is now output to `stderr` otherwise it's not shown.

Closes GUS-W-8799411.
Refs #86.