### PR TITLE
Gracefully handle carriage return in package names

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,7 +80,7 @@ APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES -o dir::etc::sour
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
-for PACKAGE in $(cat $BUILD_DIR/Aptfile | grep -v -s -e '^#' | grep -v -s -e "^:repo:"); do
+for PACKAGE in $(cat $BUILD_DIR/Aptfile | sed -e 's/\r//g' | grep -v -s -e '^#' | grep -v -s -e "^:repo:"); do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-apt/issues/53

I don't know how to run a test suite on this, so I did some manual testing within a heroku/heroku:18 docker image. Here is that testing:

```bash
root@10d7dcaf938e:/# echo -e "This is line one\r\nThis is line two\r\nThis is line three" > test_broken_lines
root@10d7dcaf938e:/# cat test_broken_lines | grep -P '\r' | cat
This is line one
This is line two
root@10d7dcaf938e:/# cat test_broken_lines | sed -e 's/\r//g'
This is line one
This is line two
This is line three
root@10d7dcaf938e:/# cat test_broken_lines | sed -e 's/\r//g' | grep -P '\r' | cat
root@10d7dcaf938e:/#
```