### PR TITLE
Add `bin/report` script to capture buildpack metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `bin/report` script to capture buildpack metadata
 
 ## 2021-03-10
 

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# bin/report <build-dir> <cache-dir> <env-dir>
+
+### Configure environment
+
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+
+BUILD_DIR=${1:-}
+
+# <separator> <array>
+joinArrayWithSeparator() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+packages=()
+custom_packages=()
+custom_repositories=()
+
+while IFS= read -r line; do
+  if [[ $line ]]; then
+    if echo "${line}" | grep -q -e "^:repo:"; then
+      custom_repositories+=("${line//:repo:/}")
+    elif [[ $line == *deb ]]; then
+      custom_packages+=("${line}")
+    else
+      packages+=("${line}")
+    fi
+  fi
+done < <(grep -v -s -e '^#' < "${BUILD_DIR}/Aptfile")
+
+echo "packages: \"$(joinArrayWithSeparator "," "${packages[@]}")\""
+echo "custom_packages: \"$(joinArrayWithSeparator "," "${custom_packages[@]}")\""
+echo "custom_repositories: \"$(joinArrayWithSeparator "," "${custom_repositories[@]}")\""

--- a/bin/report
+++ b/bin/report
@@ -8,13 +8,6 @@ set -o pipefail   # don't ignore exit codes when piping output
 
 BUILD_DIR=${1:-}
 
-# <separator> <array>
-joinArrayWithSeparator() {
-  local IFS="$1"
-  shift
-  echo "$*"
-}
-
 packages=()
 custom_packages=()
 custom_repositories=()
@@ -31,6 +24,17 @@ while IFS= read -r line; do
   fi
 done < "${BUILD_DIR}/Aptfile"
 
-echo "packages: \"$(joinArrayWithSeparator "," "${packages[@]}")\""
-echo "custom_packages: \"$(joinArrayWithSeparator "," "${custom_packages[@]}")\""
-echo "custom_repositories: \"$(joinArrayWithSeparator "," "${custom_repositories[@]}")\""
+output_key_value() {
+  local key value
+  key="$1"
+  shift
+  # sort & join the array values with a ',' then escape both '\' and '"' characters
+  value=$(printf '%s\n' "$@" | sort | tr '\n' ',' | sed 's/,$/\n/' | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+  if [[ -n "${value}" ]]; then
+    echo "$key: \"$value\""
+  fi
+}
+
+output_key_value "packages" "${packages[@]}"
+output_key_value "custom_packages" "${custom_packages[@]}"
+output_key_value "custom_repositories" "${custom_repositories[@]}"

--- a/bin/report
+++ b/bin/report
@@ -20,8 +20,8 @@ custom_packages=()
 custom_repositories=()
 
 while IFS= read -r line; do
-  if [[ $line ]]; then
-    if echo "${line}" | grep -q -e "^:repo:"; then
+  if grep --silent --invert-match -e "^#" -e "^\s*$" <<< "${line}"; then
+    if grep --silent -e "^:repo:" <<< "${line}"; then
       custom_repositories+=("${line//:repo:/}")
     elif [[ $line == *deb ]]; then
       custom_packages+=("${line}")
@@ -29,7 +29,7 @@ while IFS= read -r line; do
       packages+=("${line}")
     fi
   fi
-done < <(grep -v -s -e '^#' < "${BUILD_DIR}/Aptfile")
+done < "${BUILD_DIR}/Aptfile"
 
 echo "packages: \"$(joinArrayWithSeparator "," "${packages[@]}")\""
 echo "custom_packages: \"$(joinArrayWithSeparator "," "${custom_packages[@]}")\""

--- a/bin/report
+++ b/bin/report
@@ -20,7 +20,7 @@ while IFS= read -r line; do
   else
     packages+=("${line}")
   fi
-done < <(grep --invert-match -e "^#" -e "^\s*$" < "${BUILD_DIR}/Aptfile")
+done < <(grep --invert-match -e "^#" -e "^\s*$" "${BUILD_DIR}/Aptfile")
 
 output_key_value() {
   local key value

--- a/bin/report
+++ b/bin/report
@@ -13,16 +13,14 @@ custom_packages=()
 custom_repositories=()
 
 while IFS= read -r line; do
-  if grep --silent --invert-match -e "^#" -e "^\s*$" <<< "${line}"; then
-    if grep --silent -e "^:repo:" <<< "${line}"; then
-      custom_repositories+=("${line//:repo:/}")
-    elif [[ $line == *deb ]]; then
-      custom_packages+=("${line}")
-    else
-      packages+=("${line}")
-    fi
+  if grep --silent -e "^:repo:" <<< "${line}"; then
+    custom_repositories+=("${line//:repo:/}")
+  elif [[ $line == *deb ]]; then
+    custom_packages+=("${line}")
+  else
+    packages+=("${line}")
   fi
-done < "${BUILD_DIR}/Aptfile"
+done < <(grep --invert-match -e "^#" -e "^\s*$" < "${BUILD_DIR}/Aptfile")
 
 output_key_value() {
   local key value


### PR DESCRIPTION
Captures buildpack information including:
- packages requested
- custom Debian urls requested
- custom repositories requested

[W-15039947](https://gus.lightning.force.com/lightning/r/a07EE00001k7v4BYAQ/view)