### PR TITLE
Redirect stderr to stdout for apt-get update

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,7 +78,7 @@ APT_OPTIONS=("-o" "debug::nolocking=true" "-o" "dir::cache=$APT_CACHE_DIR" "-o" 
 APT_OPTIONS+=("-o" "dir::etc::sourcelist=$APT_SOURCES" "-o" "dir::etc::sourceparts=/dev/null")
 
 topic "Updating apt caches"
-apt-get "${APT_OPTIONS[@]}" update | indent
+apt-get "${APT_OPTIONS[@]}" update 2>&1 | indent
 
 for PACKAGE in $(cat "$BUILD_DIR/Aptfile" | grep -v -s -e '^#' | grep -v -s -e "^:repo:"); do
   if [[ $PACKAGE == *deb ]]; then

--- a/test/run
+++ b/test/run
@@ -10,6 +10,7 @@ testCompilePackageNames() {
   assertCaptured "Installing mysql-client-core"
   assertCaptured "Writing profile script"
   assertCaptured "Rewrite package-config files"
+  assertCapturedSuccess
 }
 
 testReportPackageNames() {
@@ -31,6 +32,7 @@ testCompileCustomPackageUrl() {
   assertCaptured "Installing wkhtmltox"
   assertCaptured "Writing profile script"
   assertCaptured "Rewrite package-config files"
+  assertCapturedSuccess
 }
 
 testReportCustomPackageUrl() {
@@ -42,6 +44,7 @@ testReportCustomPackageUrl() {
   assertNotCaptured "^packages"
   assertCaptured "custom_packages: \"${download_urls[$STACK]}\""
   assertNotCaptured "custom_repositories"
+  assertCapturedSuccess
 }
 
 testCompileCustomRepository() {
@@ -57,6 +60,7 @@ testCompileCustomRepository() {
   assertCaptured "Installing fasttracker2"
   assertCaptured "Writing profile script"
   assertCaptured "Rewrite package-config files"
+  assertCapturedSuccess
 }
 
 testReportCustomRepository() {
@@ -68,6 +72,7 @@ testReportCustomRepository() {
   assertCaptured "packages: \"fasttracker2\""
   assertNotCaptured "custom_packages"
   assertCaptured "custom_repositories: \"deb http://us.archive.ubuntu.com/ubuntu/ ${ubuntu_release_names[$STACK]} multiverse\""
+  assertCapturedSuccess
 }
 
 pushd "$(dirname 0)" >/dev/null || exit 1


### PR DESCRIPTION
The warning emitted by `apt-get update` prevents the test suite from being able to `assertCapturedSuccess` so redirecting it from `stderr` to `stdout`.