### PR TITLE
Allow multiple packages on a single Aptfile line

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,7 +89,12 @@ while IFS= read -r PACKAGE; do
     curl --silent --show-error --fail -L -z "$PACKAGE_FILE" -o "$PACKAGE_FILE" "$PACKAGE" 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get "${APT_OPTIONS[@]}" -y "${APT_FORCE_YES[@]}" -d install --reinstall "$PACKAGE" | indent
+    # while this is not documented behavior, the Aptfile format technically
+    # did allow for multiple packages separated by spaces to be specified
+    # on a single line due to how the download command was implemented so we
+    # should respect that behavior since users are doing this
+    IFS=$' \t' read -ra PACKAGE_NAMES <<< "$PACKAGE"
+    apt-get "${APT_OPTIONS[@]}" -y "${APT_FORCE_YES[@]}" -d install --reinstall "${PACKAGE_NAMES[@]}" | indent
   fi
 done < <(grep --invert-match -e "^#" -e "^\s*$" -e "^:repo:" "${BUILD_DIR}/Aptfile")
 

--- a/bin/report
+++ b/bin/report
@@ -18,9 +18,6 @@ while IFS= read -r line; do
   elif [[ $line == *deb ]]; then
     custom_packages+=("${line}")
   else
-    # while this is not documented behavior, the Aptfile format technically
-    # does allow for multiple packages separated by spaces to be specified
-    # on a single line due to how the download command is implemented
     IFS=$' \t' read -ra package_names <<< "${line}"
     for package_name in "${package_names[@]}"; do
       packages+=("${package_name}")

--- a/test/fixtures/package-names/Aptfile
+++ b/test/fixtures/package-names/Aptfile
@@ -3,3 +3,6 @@ xmlsec1
 
 # globbed package
 mysql-client-*
+
+# multiple packages on single line
+s3cmd wget

--- a/test/run
+++ b/test/run
@@ -4,8 +4,11 @@ testCompilePackageNames() {
   compile "package-names"
   assertCaptured "Updating apt caches"
   assertCaptured "Fetching .debs for xmlsec1"
+  assertCaptured "Fetching .debs for s3cmd wget"
   assertCaptured "Fetching .debs for mysql-client-*"
   assertCaptured "Installing xmlsec1"
+  assertCaptured "Installing s3cmd"
+  assertCaptured "Installing wget"
   assertCaptured "Installing mysql-client"
   assertCaptured "Installing mysql-client-core"
   assertCaptured "Writing profile script"
@@ -15,7 +18,7 @@ testCompilePackageNames() {
 
 testReportPackageNames() {
   report "package-names"
-  assertCaptured "packages: \"mysql-client-*,xmlsec1\""
+  assertCaptured "packages: \"mysql-client-*,s3cmd,wget,xmlsec1\""
   assertNotCaptured "custom_packages"
   assertNotCaptured "custom_repositories"
   assertCapturedSuccess


### PR DESCRIPTION
This is already being done in the wild, so adding a test and ensuring that the apt install can still proceed which fixes the regression from #115.