### PR TITLE
Warn and exit when no packages are listed in Aptfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Warn when Aptfile contains no packages ([#126](https://github.com/heroku/heroku-buildpack-apt/pull/126))
+
 ## 2024-03-14
 
 - Shell hardening ([#115](https://github.com/heroku/heroku-buildpack-apt/pull/115))

--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,16 @@ function indent() {
   esac
 }
 
+if ! grep --invert-match -e "^\s*#" -e "^\s*$" -e "^:repo:" -q "${BUILD_DIR}/Aptfile"; then
+  echo "
+!       You have no packages listed in your Aptfile. If you don't need custom Apt packages,
+!       delete your Aptfile and remove the buildpack with:
+!
+!       $ heroku buildpacks:remove heroku-community/apt
+"
+  exit 0
+fi
+
 # Store which STACK we are running on in the cache to bust the cache if it changes
 if [[ -f "$CACHE_DIR/.apt/STACK" ]]; then
   CACHED_STACK=$(cat "$CACHE_DIR/.apt/STACK")

--- a/test/fixtures/custom-repository-no-packages/Aptfile
+++ b/test/fixtures/custom-repository-no-packages/Aptfile
@@ -1,0 +1,1 @@
+:repo:deb http://us.archive.ubuntu.com/ubuntu/ jammy multiverse

--- a/test/fixtures/only-comments/Aptfile
+++ b/test/fixtures/only-comments/Aptfile
@@ -1,0 +1,4 @@
+# no packages
+  # only comments
+
+# and whitespace

--- a/test/run
+++ b/test/run
@@ -78,6 +78,51 @@ testReportCustomRepository() {
   assertCapturedSuccess
 }
 
+testCompileEmpty() {
+  compile "empty"
+  assertCaptured "You have no packages listed in your Aptfile"
+  assertNotCaptured "Updating apt caches"
+  assertCapturedSuccess
+}
+
+testReportEmpty() {
+  report "empty"
+  assertNotCaptured "^packages"
+  assertNotCaptured "custom_packages"
+  assertNotCaptured "custom_repositories"
+  assertCapturedSuccess
+}
+
+testCompileOnlyComments() {
+  compile "only-comments"
+  assertCaptured "You have no packages listed in your Aptfile"
+  assertNotCaptured "Updating apt caches"
+  assertCapturedSuccess
+}
+
+testReportOnlyComments() {
+  report "only-comments"
+  assertNotCaptured "^packages"
+  assertNotCaptured "custom_packages"
+  assertNotCaptured "custom_repositories"
+  assertCapturedSuccess
+}
+
+testCompileCustomRepositoryNoPackages() {
+  compile "custom-repository-no-packages"
+  assertCaptured "You have no packages listed in your Aptfile"
+  assertNotCaptured "Updating apt caches"
+  assertCapturedSuccess
+}
+
+testReportCustomRepositoryNoPackages() {
+  report "custom-repository-no-packages"
+  assertNotCaptured "^packages"
+  assertNotCaptured "custom_packages"
+  assertCaptured "custom_repositories: \"deb http://us.archive.ubuntu.com/ubuntu/ jammy multiverse\""
+  assertCapturedSuccess
+}
+
 pushd "$(dirname 0)" >/dev/null || exit 1
 popd >/dev/null || exit 1
 


### PR DESCRIPTION
This PR fixes an error that occurs if an Aptfile with no packages is used, that was introduced by https://github.com/heroku/heroku-buildpack-apt/pull/115. This case is detected now and a warning is printed advising that the buildpack and Aptfile should be removed before exiting the build.

Fixes #117 