### PR TITLE
Add buildpack.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The cache is now correctly invalidated if the stack version of an existing cache cannot be determined. ([#133](https://github.com/heroku/heroku-buildpack-apt/pull/133))
 - When the cache is invalidated, all APT-related files are now removed, rather than only some of them. In particular, this means old APT package index files are cleaned up. ([#133](https://github.com/heroku/heroku-buildpack-apt/pull/133))
+- Exclude test/development files from the buildpack archive published to the buildpack registry. ([#135](https://github.com/heroku/heroku-buildpack-apt/pull/135))
 
 ## 2024-03-28
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,0 +1,10 @@
+[buildpack]
+name = "Apt"
+
+[publish.Ignore]
+files = [
+  ".github/",
+  "test/",
+  ".gitignore",
+  "Makefile",
+]


### PR DESCRIPTION
With a `[publish.Ignore]` table, to exclude unnecessary files from the buildpack archive published to the buildpack registry.

For prior art, see:
https://github.com/heroku/heroku-buildpack-python/blob/main/buildpack.toml