### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github actions"
+      - "skip changelog"


### PR DESCRIPTION
Since all components in the Heroku Component Inventory are required to have one.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

GUS-W-17981045.