### PR TITLE
Remove Heroku-20 references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["20", "22", "24"]
+        stack_number: ["22", "24"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-test: heroku-24-build heroku-22-build heroku-20-build
+test: heroku-24-build heroku-22-build
 
 shellcheck:
 	@shellcheck -x bin/compile bin/detect bin/release bin/report
@@ -11,9 +11,4 @@ heroku-24-build:
 heroku-22-build:
 	@echo "Running tests in docker (heroku-22-build)..."
 	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-22" heroku/heroku:22-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
-	@echo ""
-
-heroku-20-build:
-	@echo "Running tests in docker (heroku-20-build)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
 	@echo ""

--- a/test/fixtures/custom-package-url-heroku-20/Aptfile
+++ b/test/fixtures/custom-package-url-heroku-20/Aptfile
@@ -1,1 +1,0 @@
-https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb

--- a/test/fixtures/custom-repository-heroku-20/Aptfile
+++ b/test/fixtures/custom-repository-heroku-20/Aptfile
@@ -1,2 +1,0 @@
-:repo:deb http://us.archive.ubuntu.com/ubuntu/ focal multiverse
-fasttracker2

--- a/test/run
+++ b/test/run
@@ -76,7 +76,6 @@ testReportPackageNames() {
 
 testCompileCustomPackageUrl() {
   declare -A download_urls=(
-    [heroku-20]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb"
     [heroku-22]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
     # no noble package for wkhtmltopdf yet, so using jammy package
     [heroku-24]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
@@ -92,7 +91,6 @@ testCompileCustomPackageUrl() {
 
 testReportCustomPackageUrl() {
   declare -A download_urls=(
-    [heroku-20]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb"
     [heroku-22]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
     # no noble package for wkhtmltopdf yet, so using jammy package
     [heroku-24]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
@@ -106,7 +104,6 @@ testReportCustomPackageUrl() {
 
 testCompileCustomRepository() {
   declare -A ubuntu_release_names=(
-    [heroku-20]="focal"
     [heroku-22]="jammy"
     [heroku-24]="noble"
   )
@@ -123,7 +120,6 @@ testCompileCustomRepository() {
 
 testReportCustomRepository() {
   declare -A ubuntu_release_names=(
-      [heroku-20]="focal"
       [heroku-22]="jammy"
       [heroku-24]="noble"
     )


### PR DESCRIPTION
As [announced here](https://devcenter.heroku.com/changelog-items/3230), the `heroku-20` stack is no longer supported for builds on Heroku. This PR drops all references for the now end-of-life stack.