### PR TITLE
Test against Heroku-26 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["22", "24"]
+        stack_number: ["22", "24", "26"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-test: heroku-24-build heroku-22-build
+test: heroku-26-build heroku-24-build heroku-22-build
 
 shellcheck:
 	@shellcheck -x bin/compile bin/detect bin/release bin/report
+
+heroku-26-build:
+	@echo "Running tests in docker (heroku-26-build)..."
+	@docker run --user root -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-26" heroku/heroku:26-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@echo ""
 
 heroku-24-build:
 	@echo "Running tests in docker (heroku-24-build)..."

--- a/test/fixtures/custom-package-url-heroku-26/Aptfile
+++ b/test/fixtures/custom-package-url-heroku-26/Aptfile
@@ -1,0 +1,2 @@
+# no resolute package for wkhtmltopdf yet, so using jammy package
+https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb

--- a/test/fixtures/custom-repository-heroku-22/Aptfile
+++ b/test/fixtures/custom-repository-heroku-22/Aptfile
@@ -1,2 +1,2 @@
 :repo:deb http://us.archive.ubuntu.com/ubuntu/ jammy multiverse
-fasttracker2
+translate-shell

--- a/test/fixtures/custom-repository-heroku-24/Aptfile
+++ b/test/fixtures/custom-repository-heroku-24/Aptfile
@@ -1,2 +1,2 @@
 :repo:deb http://us.archive.ubuntu.com/ubuntu/ noble multiverse
-fasttracker2
+translate-shell

--- a/test/fixtures/custom-repository-heroku-26/Aptfile
+++ b/test/fixtures/custom-repository-heroku-26/Aptfile
@@ -1,0 +1,2 @@
+:repo:deb http://us.archive.ubuntu.com/ubuntu/ resolute multiverse
+translate-shell

--- a/test/run
+++ b/test/run
@@ -79,6 +79,8 @@ testCompileCustomPackageUrl() {
     [heroku-22]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
     # no noble package for wkhtmltopdf yet, so using jammy package
     [heroku-24]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
+    # no resolute package for wkhtmltopdf yet, so using jammy package
+    [heroku-26]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
   )
   compile "custom-package-url-$STACK"
   assertCaptured "Updating APT package index"
@@ -94,6 +96,8 @@ testReportCustomPackageUrl() {
     [heroku-22]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
     # no noble package for wkhtmltopdf yet, so using jammy package
     [heroku-24]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
+    # no resolute package for wkhtmltopdf yet, so using jammy package
+    [heroku-26]="https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb"
   )
   report "custom-package-url-$STACK"
   assertNotCaptured "^packages"
@@ -106,13 +110,15 @@ testCompileCustomRepository() {
   declare -A ubuntu_release_names=(
     [heroku-22]="jammy"
     [heroku-24]="noble"
+    [heroku-26]="resolute"
   )
+  arch="$(dpkg --print-architecture)"
   compile "custom-repository-$STACK"
   assertCaptured "Adding custom repositories"
   assertCaptured "Updating APT package index"
-  assertCaptured "http://us.archive.ubuntu.com/ubuntu ${ubuntu_release_names[$STACK]}/multiverse amd64 Packages"
-  assertCaptured "Fetching .debs for fasttracker2"
-  assertCaptured "Installing fasttracker2"
+  assertCaptured "http://us.archive.ubuntu.com/ubuntu ${ubuntu_release_names[$STACK]}/multiverse ${arch} Packages"
+  assertCaptured "Fetching .debs for translate-shell"
+  assertCaptured "Installing translate-shell"
   assertCaptured "Writing profile script"
   assertCaptured "Rewrite package-config files"
   assertCapturedSuccess
@@ -122,9 +128,10 @@ testReportCustomRepository() {
   declare -A ubuntu_release_names=(
       [heroku-22]="jammy"
       [heroku-24]="noble"
+      [heroku-26]="resolute"
     )
   report "custom-repository-$STACK"
-  assertCaptured "packages: \"fasttracker2\""
+  assertCaptured "packages: \"translate-shell\""
   assertNotCaptured "custom_packages"
   assertCaptured "custom_repositories: \"deb http://us.archive.ubuntu.com/ubuntu/ ${ubuntu_release_names[$STACK]} multiverse\""
   assertCapturedSuccess


### PR DESCRIPTION
The buildpack itself didn't need any changes to work with Heroku-26.

However, some test fixtures needed updating since the example packages they were using weren't available on Ubuntu 26.04 (Resolute).

GUS-W-20776604.